### PR TITLE
Avoid const in strict mode on old node

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var isExtendable = require('is-extendable');
 
 module.exports = Object.assign || function(obj/*, objects*/) {
   if (obj === null || typeof obj === 'undefined') {
-    throw new TypeError('expected an object');
+    throw new TypeError('Cannot convert undefined or null to object');
   }
   if (!isObject(obj)) {
     obj = {};

--- a/index.js
+++ b/index.js
@@ -6,8 +6,14 @@ module.exports = Object.assign || function(obj/*, objects*/) {
   if (obj === null || typeof obj === 'undefined') {
     throw new TypeError('expected an object');
   }
+  if (!isObject(obj)) {
+    obj = {};
+  }
   for (var i = 1; i < arguments.length; i++) {
     var val = arguments[i];
+    if (isString(val)) {
+      val = toObject(val);
+    }
     if (isObject(val)) {
       assign(obj, val);
     }
@@ -21,6 +27,18 @@ function assign(a, b) {
       a[key] = b[key];
     }
   }
+}
+
+function isString(val) {
+  return (val && typeof val === 'string');
+}
+
+function toObject(str) {
+  var obj = {};
+  for (var i in str) {
+    obj[i] = str[i];
+  }
+  return obj;
 }
 
 function isObject(val) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var isExtendable = require('is-extendable');
+var assignSymbols = require('assign-symbols');
 
 module.exports = Object.assign || function(obj/*, objects*/) {
   if (obj === null || typeof obj === 'undefined') {
@@ -16,6 +17,7 @@ module.exports = Object.assign || function(obj/*, objects*/) {
     }
     if (isObject(val)) {
       assign(obj, val);
+      assignSymbols(obj, val);
     }
   }
   return obj;
@@ -25,16 +27,6 @@ function assign(a, b) {
   for (var key in b) {
     if (hasOwn(b, key)) {
       a[key] = b[key];
-    }
-  }
-
-  if (typeof Object.getOwnPropertySymbols === 'function') {
-    var symbols = Object.getOwnPropertySymbols(b);
-    for (var i = 0; i <= symbols.length; i++) {
-      var symbol = symbols[i];
-      if (isEnum(b, symbol)) {
-        a[symbol] = b[symbol];
-      }
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,16 @@ function assign(a, b) {
       a[key] = b[key];
     }
   }
+
+  if (typeof Object.getOwnPropertySymbols === 'function') {
+    var symbols = Object.getOwnPropertySymbols(b);
+    for (var i = 0; i <= symbols.length; i++) {
+      var symbol = symbols[i];
+      if (isEnum(b, symbol)) {
+        a[symbol] = b[symbol];
+      }
+    }
+  }
 }
 
 function isString(val) {
@@ -51,4 +61,8 @@ function isObject(val) {
 
 function hasOwn(obj, key) {
   return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function isEnum(obj, key) {
+  return Object.prototype.propertyIsEnumerable.call(obj, key);
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "assign-symbols": "^1.0.0",
     "is-extendable": "^1.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -8,11 +8,11 @@
 'use strict';
 
 require('mocha');
-const hasSymbol = typeof global.Symbol === 'function';
-const path = require('path');
-const argv = require('minimist')(process.argv.slice(2));
-const assert = require('assert');
-const extend = require('./');
+var hasSymbol = typeof global.Symbol === 'function';
+var path = require('path');
+var argv = require('minimist')(process.argv.slice(2));
+var assert = require('assert');
+var extend = require('./');
 
 if (argv && argv.lib) {
   extend = require(path.resolve('benchmark/code', argv.lib));
@@ -31,21 +31,21 @@ describe('extend', function() {
   });
 
   it('should extend a regex', function() {
-    const fixture = /foo/;
+    var fixture = /foo/;
     extend(fixture, {a: 'b'}, new Date(), {c: 'd'});
     assert.equal(fixture.a, 'b');
     assert.equal(fixture.c, 'd');
   });
 
   it('should extend a function', function() {
-    const fixture = function() {};
+    var fixture = function() {};
     extend(fixture, {a: 'b'}, new Date(), {c: 'd'});
     assert.equal(fixture.a, 'b');
     assert.equal(fixture.c, 'd');
   });
 
   it('should extend an array', function() {
-    const arr = [];
+    var arr = [];
     extend(arr, {a: 'b'}, new Date(), {c: 'd'});
     assert.equal(arr.a, 'b');
     assert.equal(arr.c, 'd');
@@ -69,24 +69,24 @@ describe('extend', function() {
 
   it('should not extend non-enumerable symbols', function() {
     if (!hasSymbol) return this.skip();
-    const fixture = {};
-    const obj = {};
-    const symbol = Symbol('foo');
+    var fixture = {};
+    var obj = {};
+    var symbol = Symbol('foo');
     Object.defineProperty(obj, symbol, {enumerable: false, value: 'bar'});
     extend(fixture, obj);
-    const other = extend({}, obj);
+    var other = extend({}, obj);
     assert.equal(typeof fixture[symbol], 'undefined');
     assert.equal(typeof other[symbol], 'undefined');
   });
 
   it('should extend symbol properties', function() {
     if (!hasSymbol) return this.skip();
-    const fixture = {};
-    const obj = {};
-    const symbol = Symbol('foo');
+    var fixture = {};
+    var obj = {};
+    var symbol = Symbol('foo');
     obj[symbol] = 'bar';
     extend(fixture, obj);
-    const other = extend({}, obj);
+    var other = extend({}, obj);
     assert.equal(fixture[symbol], 'bar');
     assert.equal(other[symbol], 'bar');
   });


### PR DESCRIPTION
@jonschlinkert this shows the problems in old node.  We weren't seeing them due to `const` usage in strict mode.  I'll fix the problems inline with this PR.